### PR TITLE
Add support for signed JWT passes on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A module built with [Expo Modules](https://docs.expo.dev/modules/overview/) that provides wallet features for iOS and Android.
 
-Uses [PassKit](https://developer.apple.com/documentation/passkit/wallet) on iOS, [Google Wallet API](https://developers.google.com/wallet/generic) on Android.
+Uses [PassKit](https://developer.apple.com/documentation/passkit/wallet) on iOS, [Google Wallet API](https://developers.google.com/wallet/generic) on Android. This now supports both signed and unsigned JWTs for Android.
 
 <img src="https://github.com/premieroctet/react-native-wallet/assets/11079152/ef45634f-a671-403d-b7dd-211af2d612b8" width="300" height="auto" />
 <img src="https://github.com/premieroctet/react-native-wallet/assets/11079152/5c27516d-37b8-434e-b8e9-7731cca0a5ee" width="300" height="auto"  />
@@ -88,7 +88,8 @@ export default function App() {
 #### Methods
 
 - `canAddPasses(): boolean`: Check if the device can add passes.
-- `addPass(urlOrToken: string): Promise<boolean>`: Add a pass to the wallet. Returns `true` if the pass was added or if its already added. Returns `false` if the user cancelled the operation. `urlOrToken` should be the pkpass URL for iOS, and the pass JWT for Android.
+- `addPass(urlOrToken: string): Promise<boolean>`: Add a pass to the wallet. Returns `true` if the pass was added or if its already added. Returns `false` if the user cancelled the operation. `urlOrToken` should be the pkpass URL for iOS, and the **unsigned** pass JWT for Android. [Read more here](https://developers.google.com/wallet/generic/android#add-a-pass)
+- `addPassWithSignedJwt(signedJwt: string): Promise<boolean>`: Add a pass to the wallet using a signed JWT. Returns `true` if the pass was added or if its already added. Returns `false` if the user cancelled the operation. This is for Android only. [Read more here](https://developers.google.com/wallet/generic/android#add-a-pass)
 - `hasPass(urlOrToken: string): Promise<boolean>`: Check if a pass exists in the wallet. Returns `true` if the pass exists, `false` otherwise. On Android, this always returns `false`.
 - `removePass(urlOrToken: string): Promise<void>`: Remove a pass from the wallet. On Android, this is no-op. On iOS, make sure you have the correct entitlements. See [documentation](https://developer.apple.com/documentation/passkit/pkpasslibrary/1617083-removepass#discussion).
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,12 +54,12 @@ android {
   compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
   }
 
   kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.majorVersion
+    jvmTarget = JavaVersion.VERSION_17.majorVersion
   }
 
   namespace "com.premieroctet.wallet"

--- a/android/src/main/java/com/premieroctet/wallet/RNWalletModule.kt
+++ b/android/src/main/java/com/premieroctet/wallet/RNWalletModule.kt
@@ -50,6 +50,15 @@ class RNWalletModule : Module() {
       addPassPromise = promise
     }
 
+    AsyncFunction("addPassWithSignedJwt") { jwt: String, promise: Promise ->
+      if (appContext.currentActivity == null) {
+        promise.reject(CodedException("Current activity not found"))
+        return@AsyncFunction
+      }
+      walletClient.savePassesJwt(jwt, appContext.currentActivity!!, addToGoogleWalletRequestCode)
+      addPassPromise = promise
+    }
+
     OnCreate {
       if (appContext.reactContext != null) {
         walletClient = Pay.getClient(appContext.reactContext!!.applicationContext)

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,21 @@ export function addPass(urlOrToken: string): Promise<boolean> {
 }
 
 /**
+ * @param signedJwt The signed JWT
+ * @returns boolean indicating if the pass was added
+ *
+ * @platform android
+ */
+export function addPassWithSignedJwt(signedJwt: string): Promise<boolean> {
+  if (Platform.OS !== "android") {
+    console.warn("RNWallet.addPassWithSignedJwt is only available on Android");
+    return Promise.resolve(false);
+  }
+
+  return RNWalletModule.addPassWithSignedJwt(signedJwt);
+}
+
+/**
  * @param url The pkpass file url
  * @returns boolean indicating if the pass exists in the wallet
  *


### PR DESCRIPTION
- Introduces the `addPassWithSignedJwt` method for Android, allowing passes to be added using signed JWTs. Updates documentation to reflect the new method and clarifies usage of unsigned and signed JWTs.
- Also updates Android build configuration to use Java 17.

Closes #1 
maybe closes #2 (assuming they could've been running into the same issue of trying to add a signed jwt against the unsigned workflow method)

Let me know you need anything else here @baptadn @foyarash -- I like that this library is written with the ExpoModules api and hope that we can continue to make it better!